### PR TITLE
Make node2vec in karateclub plugin use epochs and learning rate

### DIFF
--- a/metagraph_karateclub/plugins/karateclub/algorithms.py
+++ b/metagraph_karateclub/plugins/karateclub/algorithms.py
@@ -31,6 +31,8 @@ if has_karateclub:
             p=p,
             q=q,
             dimensions=embedding_size,
+            epochs=epochs,
+            learning_rate=learning_rate,
         )
         old2canonical = {
             node: canonical_index


### PR DESCRIPTION
The previous implementation was always using the defualt learning rate and number of epochs rather than the ones passed in. This commit intended to fix that.