### PR TITLE
Update environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,16 +12,7 @@ dependencies:
   - black
   - conda-forge::pre-commit
   - setuptools
-
-# metagraph dependencies
-  - importlib_metadata
-  - numpy
-  - networkx
-  - pandas
-  - conda-forge::python-louvain
-  - scipy
-  - conda-forge::donfig
-  - conda-forge::grblas
+  - metagraph::metagraph
 
 # metagraph-karateclub dependencies
   - conda-forge::karateclub


### PR DESCRIPTION
This PR makes the `environment.yml` use `metagraph::metagraph` instead of enumerating all the dependencies of `metagraph`.

This PR follows the suggestion made in [this comment](https://github.com/metagraph-dev/metagraph-stellargraph/pull/1#discussion_r513536028).