### PR TITLE
Update embedding.train.node2vec to not use NodeEmbedding

### DIFF
--- a/metagraph_karateclub/plugins/__init__.py
+++ b/metagraph_karateclub/plugins/__init__.py
@@ -20,7 +20,5 @@ def find_plugins():
     # Ensure we import all items we want registered
     from . import karateclub
 
-    registry.register_from_modules(
-        karateclub, name="metagraph_karateclub_karateclub"
-    )  # TODO should we have a better naming convention?
+    registry.register_from_modules(karateclub)
     return registry.plugins

--- a/metagraph_karateclub/plugins/karateclub/algorithms.py
+++ b/metagraph_karateclub/plugins/karateclub/algorithms.py
@@ -1,3 +1,4 @@
+import metagraph as mg
 from metagraph import concrete_algorithm
 from .. import has_karateclub
 from typing import Tuple
@@ -46,3 +47,36 @@ if has_karateclub:
             np.arange(len(graph.value.nodes)), node_ids=old2canonical
         )
         return (matrix, node2index)
+
+    @concrete_algorithm("embedding.train.graph2vec")
+    def karateclub_graph2vec_train(
+        graphs: mg.List[NetworkXGraph],
+        subgraph_degree: int,
+        embedding_size: int,
+        epochs: int,
+        learning_rate: float,
+        worker_count: int = 1,
+    ) -> NumpyMatrix:
+        if not all(nx.is_connected(graph.value) for graph in graphs):
+            raise ValueError("Graphs must be connected")
+        graph2vec_trainer = karateclub.Graph2Vec(
+            wl_iterations=subgraph_degree,
+            dimensions=embedding_size,
+            workers=worker_count,
+            epochs=epochs,
+            learning_rate=learning_rate,
+            min_count=0,
+        )
+        graph2vec_trainer.fit(
+            [
+                nx.relabel_nodes(
+                    graph.value,
+                    dict(map(reversed, enumerate(graph.value.nodes))),
+                    copy=True,
+                )
+                for graph in graphs
+            ]
+        )
+        np_embedding_matrix = graph2vec_trainer.get_embedding()
+        matrix = NumpyMatrix(np_embedding_matrix)
+        return matrix

--- a/metagraph_karateclub/plugins/karateclub/algorithms.py
+++ b/metagraph_karateclub/plugins/karateclub/algorithms.py
@@ -1,5 +1,6 @@
 from metagraph import concrete_algorithm
 from .. import has_karateclub
+from typing import Tuple
 
 if has_karateclub:
     import karateclub
@@ -9,7 +10,6 @@ if has_karateclub:
     from metagraph.plugins.numpy.types import (
         NumpyMatrix,
         NumpyNodeMap,
-        NumpyNodeEmbedding,
     )
 
     @concrete_algorithm("embedding.train.node2vec")
@@ -23,7 +23,7 @@ if has_karateclub:
         epochs: int,
         learning_rate: float,
         worker_count: int = 1,
-    ) -> NumpyNodeEmbedding:
+    ) -> Tuple[NumpyMatrix, NumpyNodeMap]:
         trainer = karateclub.Node2Vec(
             walk_number=walks_per_node,
             walk_length=walk_length,
@@ -45,4 +45,4 @@ if has_karateclub:
         node2index = NumpyNodeMap(
             np.arange(len(graph.value.nodes)), node_ids=old2canonical
         )
-        return NumpyNodeEmbedding(matrix, node2index)
+        return (matrix, node2index)

--- a/metagraph_karateclub/tests/__init__.py
+++ b/metagraph_karateclub/tests/__init__.py
@@ -1,0 +1,1 @@
+from metagraph.core.multiverify import MultiVerify


### PR DESCRIPTION
This PR makes `embedding.train.node2vec` not use `NodeEmbedding` since https://github.com/metagraph-dev/metagraph/pull/138 removes `NodeEmbedding`.